### PR TITLE
Correction de la documentation de la partie 3

### DIFF
--- a/p3/README.md
+++ b/p3/README.md
@@ -14,11 +14,14 @@ Cette partie du projet IoT met en place un système de déploiement continu avec
 ```
 p3/
 ├── scripts/
-│   ├── install_dep.sh    # Installation des dépendances
-│   └── lanch.sh          # Script de lancement principal
+│   ├── install_dep.sh    # Installation des dépendances (Docker, etc.)
+│   ├── 1_k3d.sh          # Création du cluster K3D
+│   ├── 2_argocd.sh       # Installation et configuration d'ArgoCD
+│   ├── 3_init.sh         # Déploiement de l'application
+│   └── delete_all.sh     # Nettoyage du cluster
 └── confs/
     ├── app.yaml          # Configuration ArgoCD Application
-    └── manifest.yaml     # Manifestes Kubernetes (Service, Ingress)
+    └── manifest.yaml     # Manifestes Kubernetes (Ingress)
 ```
 
 ## Déploiement
@@ -32,24 +35,31 @@ Exécuter le script d'installation des dépendances :
 
 ### Lancement
 
-Exécuter le script principal :
-```bash
-./scripts/lanch.sh
-```
+Exécuter les scripts dans l'ordre :
 
-Le script effectue automatiquement :
-1. Nettoyage des processus existants
-2. Création du cluster K3D `iot-cluster`
-3. Installation d'ArgoCD
-4. Déploiement de l'application
-5. Configuration de l'ingress
-6. Vérifications de santé
+1. **Création du cluster K3D** :
+```bash
+./scripts/1_k3d.sh
+```
+Crée le cluster `dvergobbS` avec les ports 80 et 443 exposés.
+
+2. **Installation d'ArgoCD** :
+```bash
+./scripts/2_argocd.sh
+```
+Installe ArgoCD, crée les namespaces `argocd` et `dev`, et lance le port-forward sur le port 8085.
+
+3. **Déploiement de l'application** :
+```bash
+./scripts/3_init.sh
+```
+Déploie l'ingress et l'application ArgoCD, puis effectue les vérifications de santé.
 
 ## URLs d'accès
 
 Une fois le déploiement terminé, les services sont accessibles via :
 
-- **ArgoCD UI** : https://localhost:8080
+- **ArgoCD UI** : https://localhost:8085 ou https://argocd.dvergobb.com:8085
   - Username: `admin`
   - Password: affiché dans le terminal après déploiement
 
@@ -71,7 +81,7 @@ Réponse attendue :
 ## Composants Kubernetes
 
 ### Service
-- **Nom** : `myapp`
+- **Nom** : `myapp-service`
 - **Port** : 8888
 - **Namespace** : `dev`
 
@@ -107,7 +117,7 @@ kubectl get pods -n argocd
 
 ### Port-forward manuel si besoin
 ```bash
-kubectl port-forward -n dev svc/myapp 8888:8888
+kubectl port-forward -n dev svc/myapp-service 8888:8888
 ```
 
 ## Notes


### PR DESCRIPTION
Corrections apportées :
- Mise à jour de la structure du projet avec les vrais scripts (1_k3d.sh, 2_argocd.sh, 3_init.sh)
- Remplacement du script inexistant "lanch.sh" par les 3 scripts séparés
- Correction du nom du cluster (iot-cluster → dvergobbS)
- Correction du port ArgoCD (8080 → 8085)
- Ajout de l'URL alternative argocd.dvergobb.com:8085
- Correction du nom du service (myapp → myapp-service)
- Mise à jour des instructions de déploiement pour refléter le processus en 3 étapes